### PR TITLE
Update name and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,20 @@ A containerized version of the weather mcp at https://modelcontextprotocol.io/qu
 
 ### Connecting Your MCP Client to a Deployed Instance
 
-For convenience, we have deployed the container using fly.io at https://getgather-weather.fly.dev/mcp. If you so desire, you can connect your MCP client directly to this instance. For example, in Claude Desktop, you can add the following to your `claude_desktop_config.json`:
+For convenience, we have deployed the container using fly.io at https://getgather-weather.fly.dev/mcp. If you so desire, you can connect your MCP client directly to this instance. For example, in Cursor/VS Code you can add the following to your `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "weather": {
+      "url": "https://getgather-weather.fly.dev/mcp"
+    }
+  }
+}
+
+Clients such as VS Code and Cursor offer true streamable http support (as well as MCP inspector), so there's no need for `npx` or `mcp-remote` commands. 
+
+If you want to test with Claude, it isn't truly using streamable http as the transport, as Claude Desktop doesn't support that yet, but it works fine for testing (claude launches a proxy that hits your endpoint). For example, in Claude Desktop, you can add the following to your `claude_desktop_config.json`:
 
 ```json
 {
@@ -46,6 +59,6 @@ Then add http://localhost:8000/mcp as a model endpoint in your MCP client. If us
 }
 ```
 
-This isn't truly using streamable http as the transport, as Claude Desktop doesn't support that yet, but it works fine for testing (claude launches a proxy that hits your endpoint). If you want true streamable http support, you can use either inspector, Claude Code, or another MCP client that supports streamable http.
+If you're not using Claude, and you're client supports http streaming directly, you will just need the local URL and `/mcp` extension as in the VS Code/Cursor example above.
 
 Remember for streamable http (including mcp-remote), you need your mcp server to be running [(as opposed to the client launching it for you as with stdio)](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#stdio).

--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@ A containerized version of the weather mcp at https://modelcontextprotocol.io/qu
 
 ## Quickstart
 
-### Run Locally with Docker
+### Connecting Your MCP Client to a Deployed Instance
 
-`$ docker run -p 8000:8000 ghcr.io/mcp-getgather/containerized-weather-mcp`
-
-Then add http://localhost:8000/mcp-weather as a model endpoint in your MCP client. If using Claude Desktop, you can add the following to your `claude_desktop_config.json` (which is found from `Claude` -> `Settings` -> `Developer` -> `Edit Config`):
+For convenience, we have deployed the container using fly.io at https://getgather-weather.fly.dev/mcp. If you so desire, you can connect your MCP client directly to this instance. For example, in Claude Desktop, you can add the following to your `claude_desktop_config.json`:
 
 ```json
 {
@@ -17,7 +15,30 @@ Then add http://localhost:8000/mcp-weather as a model endpoint in your MCP clien
       "command": "npx",
       "args": [
         "mcp-remote",
-        "http://127.0.0.1:8000/mcp-weather",
+        "https://getgather-weather.fly.dev/mcp",
+        "--allow-http"
+      ]
+    }
+  }
+}
+```
+
+### Run Locally with Docker
+
+Alternatively, you can build the Docker image locally and add the running endpoint to your client config. The following command pulls and runs the latest public image for the weather MCP.
+
+`$ docker run -p 8000:8000 ghcr.io/mcp-getgather/containerized-weather-mcp`
+
+Then add http://localhost:8000/mcp as a model endpoint in your MCP client. If using Claude Desktop, you can add the following to your `claude_desktop_config.json` (which is found from `Claude` -> `Settings` -> `Developer` -> `Edit Config`):
+
+```json
+{
+  "mcpServers": {
+    "http-weather": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "http://127.0.0.1:8000/mcp",
         "--allow-http"
       ]
     }
@@ -28,22 +49,3 @@ Then add http://localhost:8000/mcp-weather as a model endpoint in your MCP clien
 This isn't truly using streamable http as the transport, as Claude Desktop doesn't support that yet, but it works fine for testing (claude launches a proxy that hits your endpoint). If you want true streamable http support, you can use either inspector, Claude Code, or another MCP client that supports streamable http.
 
 Remember for streamable http (including mcp-remote), you need your mcp server to be running [(as opposed to the client launching it for you as with stdio)](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#stdio).
-
-### Connecting Your MCP Client to the Deployed Instance
-
-For convenience, we have deployed the container using fly.io at https://containerized-weather-mcp.fly.dev/mcp-weather. If you so desire, you can connect your MCP client to this instance. For example, in Claude Desktop, you can add the following to your `claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "http-weather": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://containerized-weather-mcp.fly.dev/mcp-weather",
-        "--allow-http"
-      ]
-    }
-  }
-}
-```

--- a/fly.toml
+++ b/fly.toml
@@ -1,9 +1,9 @@
-# fly.toml app configuration file generated for containerized-weather-mcp on 2025-08-27T16:14:55-07:00
+# fly.toml app configuration file generated for getgather-weather on 2025-08-28T13:52:15-06:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'containerized-weather-mcp'
+app = 'getgather-weather'
 primary_region = 'sjc'
 
 [build]

--- a/weather.py
+++ b/weather.py
@@ -5,7 +5,7 @@ from starlette.requests import Request
 from starlette.responses import Response, JSONResponse
 
 # Initialize FastMCP server
-mcp = FastMCP("weather", host="0.0.0.0", port=8000, streamable_http_path="/mcp-weather")
+mcp = FastMCP("weather", host="0.0.0.0", port=8000, streamable_http_path="/mcp")
 
 # Constants
 NWS_API_BASE = "https://api.weather.gov"


### PR DESCRIPTION
Changed the name of the deployed app to `getgather-weather`

Changed the endpoint to just `/mcp` instead of `/mcp-weather`

Reorganized the read me to include instructions for the deployed container first and the docker commands second.

Tested this out on claude desktop, cursor, and mcp inspector and it worked on all three. Haven't tried getting it to work on mobile yet though.