### PR TITLE
Custom connector explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,32 +6,17 @@ A containerized version of the weather mcp at https://modelcontextprotocol.io/qu
 
 ### Connecting Your MCP Client to a Deployed Instance
 
-For convenience, we have deployed the container using fly.io at https://getgather-weather.fly.dev/mcp. If you so desire, you can connect your MCP client directly to this instance. For example, in Cursor/VS Code you can add the following to your `mcp.json`:
+For convenience, we have deployed the container using fly.io at https://getgather-weather.fly.dev/mcp. 
+
+If you so desire, you can connect your MCP client directly to this instance. Clients like Claude offer an option to add custom connectors directly from the settings. Open Claude, navigate to settings, and go to the "Connectors" tab. Click on "Add custom connector" and give your connector a name. Then, in the second box for "Remore MCP server URL" you can paste `https://getgather-weather.fly.dev/mcp`. Finish by clicking "Add" (no advanced settings necessary for this!). You should see the new weather MCP appear in your list of connectors. Open a new chat in Claude and look for the server under the "Tools" icon. You should see it appear under the name you set for it.
+
+For clients that don't use custom connectors in the UI, you can always set up the weather MCP using a simple URL in the configuration JSON. For example, in Cursor/VS Code you can add the following to your `mcp.json`:
 
 ```json
 {
   "mcpServers": {
     "weather": {
       "url": "https://getgather-weather.fly.dev/mcp"
-    }
-  }
-}
-```
-
-Clients such as VS Code and Cursor offer true streamable http support (as well as MCP inspector), so there's no need for `npx` or `mcp-remote` commands. 
-
-If you want to test with Claude, it isn't truly using streamable http as the transport, as Claude Desktop doesn't support that yet, but it works fine for testing (claude launches a proxy that hits your endpoint). For example, in Claude Desktop, you can add the following to your `claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "http-weather": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://getgather-weather.fly.dev/mcp",
-        "--allow-http"
-      ]
     }
   }
 }


### PR DESCRIPTION
Added an explanation to the readme on how to add this MCP as a custom connector in claude, and removed the section on how to add it to Claude's config (if using the fly instance, it isn't necessary anyway).